### PR TITLE
Fix missing newline in feature engineering script

### DIFF
--- a/src/ml/feature_engineering.py
+++ b/src/ml/feature_engineering.py
@@ -659,4 +659,4 @@ WORLDPOP_CONFIG = {
 }
 
 if __name__ == '__main__':
-    run_feature_engineering_pipeline() 
+    run_feature_engineering_pipeline()


### PR DESCRIPTION
## Summary
- ensure a trailing newline exists in `feature_engineering.py`

## Testing
- `python -m py_compile src/ml/feature_engineering.py`

------
https://chatgpt.com/codex/tasks/task_e_6841ad3410b88325a2ac3e59a2742fb6